### PR TITLE
Fix up CI as older containers don't have pip

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,12 +99,13 @@ jobs:
           # For more details, see https://stackoverflow.com/q/71901632
           # and https://github.com/actions/checkout/issues/760
           docker exec oc git config --global --add safe.directory /workdir/octsympy
-          # < 8.x containers don't have pip
+          # < 8.x containers don't have pip, must install
+          # Can just pip (not pip3) once we drop 5.x support
           docker exec oc apt-get update
           docker exec oc apt-get install -y python3-pip
-          docker exec oc pip --version
-          docker exec oc pip install packaging
-          docker exec oc pip install sympy==$SYMPY
+          docker exec oc pip3 --version
+          docker exec oc pip3 install packaging
+          docker exec oc pip3 install sympy==$SYMPY
           docker exec oc octave-cli --eval "pkg install -forge doctest"
       - name: Run BIST in-place
         run: docker exec oc make -C octsympy test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        octave: [8.3.0]
+        octave: [8.4.0]
         sympy: [1.4, 1.5.1, 1.6.2, 1.7.1, 1.8, 1.9, 1.10.1, 1.11.1, 1.12]
         include:
           - octave: 5.1.0
@@ -80,6 +80,8 @@ jobs:
           - octave: 8.1.0
             sympy: 1.12
           - octave: 8.2.0
+            sympy: 1.12
+          - octave: 8.3.0
             sympy: 1.12
     steps:
       - uses: actions/checkout@v3
@@ -122,7 +124,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        octave: [8.3.0]
+        octave: [8.4.0]
         sympy: [1.12]
     steps:
       - uses: actions/checkout@v3
@@ -172,7 +174,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        octave: [8.3.0]
+        octave: [8.4.0]
         sympy: [1.12]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,9 @@ jobs:
           # For more details, see https://stackoverflow.com/q/71901632
           # and https://github.com/actions/checkout/issues/760
           docker exec oc git config --global --add safe.directory /workdir/octsympy
+          # < 8.x containers don't have pip
+          docker exec oc apt-get update
+          docker exec oc apt-get install -y python3-pip
           docker exec oc pip --version
           docker exec oc pip install packaging
           docker exec oc pip install sympy==$SYMPY

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
   bist_doc:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         octave: [8.4.0]
         sympy: [1.4, 1.5.1, 1.6.2, 1.7.1, 1.8, 1.9, 1.10.1, 1.11.1, 1.12]
@@ -99,8 +99,9 @@ jobs:
           # For more details, see https://stackoverflow.com/q/71901632
           # and https://github.com/actions/checkout/issues/760
           docker exec oc git config --global --add safe.directory /workdir/octsympy
-          docker exec oc pip3 install packaging
-          docker exec oc pip3 install sympy==$SYMPY
+          docker exec oc pip --version
+          docker exec oc pip install packaging
+          docker exec oc pip install sympy==$SYMPY
           docker exec oc octave-cli --eval "pkg install -forge doctest"
       - name: Run BIST in-place
         run: docker exec oc make -C octsympy test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,17 +34,17 @@ jobs:
         run: |
           echo Hello world
           uname -a
-          docker pull docker.io/gnuoctave/octave:6.4.0
+          docker pull docker.io/gnuoctave/octave
           # sudo apt-get install --no-install-recommends -y octave
           # octave --version
           ls
           cd inst
           ls
-          docker run --rm -v $PWD:/workdir:rw gnuoctave/octave:6.4.0 octave-cli --eval 'pwd; ls; disp(42); help sympref'
-          docker run --rm -v $PWD:/workdir:rw gnuoctave/octave:6.4.0 octave-cli --eval "sympref diagnose"
-          docker run --rm -v $PWD:/workdir:rw gnuoctave/octave:6.4.0 octave-cli --eval "x=sym('x'); y=sin(x/17); disp(y)"
+          docker run --rm -v $PWD:/workdir:rw gnuoctave/octave octave-cli --eval 'pwd; ls; disp(42); help sympref'
+          docker run --rm -v $PWD:/workdir:rw gnuoctave/octave octave-cli --eval "sympref diagnose"
+          docker run --rm -v $PWD:/workdir:rw gnuoctave/octave octave-cli --eval "x=sym('x'); y=sin(x/17); disp(y)"
           echo "Try a test"
-          docker run --rm -v $PWD:/workdir:rw gnuoctave/octave:6.4.0 octave-cli --eval "x=sym('x'); test @sym/qr"
+          docker run --rm -v $PWD:/workdir:rw gnuoctave/octave octave-cli --eval "x=sym('x'); test @sym/qr"
 
 
   # Built-in Self Tests and Doctests for various supported Octave and SymPy


### PR DESCRIPTION
The 8.x containers have pip but it seems we must install it on 7.x and earlier.  On 5.x, we must still use `pip3` not just `pip`.