### PR TITLE
CI: Fix typo in 4b7c301028f4c847f054c260de4f72d41535b6bf

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
         octave: [9.1.0]
         sympy: [1.5.1, 1.6.2, 1.7.1, 1.8, 1.9, 1.10.1, 1.11.1, 1.12]
         include:
-	  - octave: 5.2.0
+          - octave: 5.2.0
             sympy: 1.8
           - octave: 6.1.0
             sympy: 1.12


### PR DESCRIPTION
.yaml files don't support tabs for indentation.

See: https://github.com/gnu-octave/symbolic/actions/runs/9117864502