### PR TITLE
CI: split Oct 9 runs to their own section

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,17 +84,62 @@ jobs:
 
   # Built-in Self Tests and Doctests for various supported Octave and SymPy
   # Test newest Octave and all supported SymPy
-  # Test other supported Octave releases with latest available SymPy
-  # Note that 1.10.1 not supported on Python 3.6 (Ubuntu 18.04-based systems)
-  # Ubuntu 20.04: Octave 5.2.0
-  # Ubuntu 22.04: Octave 6.4.0
+  # Older Octave tend to need slightly different setup for pip setup
   bist_doc:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        octave: [9.1.0]
+        octave: [9.2.0]
         sympy: [1.5.1, 1.6.2, 1.7.1, 1.8, 1.9, 1.10.1, 1.11.1, 1.12]
+        include:
+          - octave: 9.1.0
+            sympy: 1.12
+    steps:
+      - uses: actions/checkout@v4
+      - name: Container setup
+        env:
+          OCT: ${{ matrix.octave }}
+          SYMPY: ${{ matrix.sympy }}
+        run: |
+          uname -a
+          docker pull docker.io/gnuoctave/octave:$OCT
+          docker run --name=oc --detach --init \
+            --volume=$PWD:/workdir/octsympy:rw \
+            gnuoctave/octave:$OCT sleep inf
+          # FIXME: workaround "fatal: unsafe repository" error
+          # For more details, see https://stackoverflow.com/q/71901632
+          # and https://github.com/actions/checkout/issues/760
+          docker exec oc git config --global --add safe.directory /workdir/octsympy
+          docker exec oc pip --version
+          A=`docker exec oc pip --version | awk '{print $2}'`
+          echo $A
+          docker exec oc pip install --break-system-packages packaging
+          docker exec oc pip install --break-system-packages sympy==$SYMPY
+          docker exec oc octave-cli --eval "pkg install -forge doctest"
+      - name: Run BIST in-place
+        run: docker exec oc make -C octsympy test
+      - name: Run doctests in-place
+        run: docker exec oc make -C octsympy doctest
+      - name: Make package, then install-load-unload-uninstall
+        run: |
+          docker exec oc make -C octsympy install
+          docker exec oc octave --eval "pkg load symbolic; sympref diagnose; syms x; clear all; pkg unload symbolic; pkg uninstall symbolic"
+      - name: Stop container
+        run: |
+          docker stop oc
+          docker rm oc
+
+
+  # Test other supported Octave releases with latest available SymPy
+  # Note that 1.10.1 not supported on Python 3.6 (Ubuntu 18.04-based systems)
+  # Ubuntu 20.04: Octave 5.2.0
+  # Ubuntu 22.04: Octave 6.4.0
+  bist_doc_old:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
         include:
           - octave: 5.2.0
             sympy: 1.8

--- a/inst/@sym/expm.m
+++ b/inst/@sym/expm.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2019, 2024 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -61,27 +61,35 @@ end
 
 %!test
 %! % scalar
+%! if (pycall_sympy__ ('return Version(spver) >= Version("1.9")'))
 %! syms x
 %! assert (isequal (expm(x), exp(x)))
+%! end
 
 %!test
 %! % diagonal
+%! if (pycall_sympy__ ('return Version(spver) >= Version("1.9")'))
 %! A = [sym(1) 0; 0 sym(3)];
 %! B = [exp(sym(1)) 0; 0 exp(sym(3))];
 %! assert (isequal (expm(A), B))
+%! end
 
 %!test
 %! % diagonal w/ x
+%! if (pycall_sympy__ ('return Version(spver) >= Version("1.9")'))
 %! syms x positive
 %! A = [sym(1) 0; 0 x+2];
 %! B = [exp(sym(1)) 0; 0 exp(x+2)];
 %! assert (isequal (expm(A), B))
+%! end
 
 %!test
 %! % non-diagonal
+%! if (pycall_sympy__ ('return Version(spver) >= Version("1.9")'))
 %! syms x positive
 %! A = [sym(1) 2; 0 x+2];
 %! B = expm(A);
 %! C = double(subs(B, x, 4));
 %! D = expm(double(subs(A, x, 4)));
 %! assert (max (max (abs (C - D))) <= 1e-11)
+%! end

--- a/inst/@sym/expm.m
+++ b/inst/@sym/expm.m
@@ -24,12 +24,14 @@
 %% Example:
 %% @example
 %% @group
+%% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) > Version("1.8")'))
 %% A = [sym(4) 1; sym(0) 4]
 %%   @result{} A = (sym 2×2 matrix)
 %%       ⎡4  1⎤
 %%       ⎢    ⎥
 %%       ⎣0  4⎦
 %%
+%% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) > Version("1.8")'))
 %% expm(A)
 %%   @result{} (sym 2×2 matrix)
 %%       ⎡ 4   4⎤


### PR DESCRIPTION
- [x] Fixes #1312.
- [x] bump Octave to 9.2.0
