### PR TITLE
Fix compatibility with BSD tar by supporting both tar and gtar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ HTML_TARBALL := ${HTML_DIR}.tar.gz
 
 OCTAVE ?= octave
 MATLAB ?= matlab
+TAR ?= tar
 
 .PHONY: help clean install test doctest dist dist_zip html matlab_test matlab_pkg
 
@@ -46,7 +47,7 @@ define create_tarball
 $(shell cd $(dir $(1)) \
     && find $(notdir $(1)) -print0 \
     | LC_ALL=C sort -z \
-    | tar c --mtime="$(GIT_DATE)" \
+    | $(TAR) c --mtime="$(GIT_DATE)" \
             --owner=root --group=root --numeric-owner \
             --no-recursion --null -T - -f - \
     | gzip -9n > "$(2)")
@@ -61,7 +62,7 @@ endef
 $(OCTAVE_RELEASE): .git/index | $(BUILD_DIR)
 	@echo "Creating package version $(VERSION) release ..."
 	-$(RM) -r "$@"
-	git archive --format=tar --prefix="$@/" HEAD | tar -x
+	git archive --format=tar --prefix="$@/" HEAD | $(TAR) -x
 	$(RM) "$@/README.matlab.md" \
 	      "$@/HOWTO-release.md" \
 	      "$@/TODO.md" \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL   := /bin/bash
 
 ## Copyright 2016-2019, 2022 Colin B. Macdonald
+## Copyright 2024 Swayam Shah
 ##
 ## Copying and distribution of this file, with or without modification,
 ## are permitted in any medium without royalty provided the copyright


### PR DESCRIPTION
This PR addresses the issue (#1315) with packaging and tarball creation on systems using BSD `tar`. On such systems, the default `tar` command may not work as expected, and GNU `tar` (`gtar`) is required instead.