### PR TITLE
misc cleanups regarding warnings

### DIFF
--- a/inst/@sym/mldivide.m
+++ b/inst/@sym/mldivide.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016, 2018-2019, 2022 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2018-2019, 2022, 2025 Colin B. Macdonald
 %% Copyright (C) 2022 Alex Vong
 %%
 %% This file is part of OctSymPy.
@@ -162,7 +162,7 @@ end
 %! y = [-2*c1 + 5 nan -2*c5; c1 nan c5];
 %! assert (isequaln (x, y))
 
-%!warning <vpa backslash>
+%!warning id=octsympy:backslash:vpa
 %! % vpa, nearly singular matrix
 %! A = sym([1 2; 2 4]);
 %! A(1,1) = vpa('1.001');
@@ -171,7 +171,7 @@ end
 %! y = [sym(0); vpa('0.5')];
 %! assert (isequal (x, y))
 
-%!warning <vpa backslash>
+%!warning id=octsympy:backslash:vpa
 %! % vpa, singular rhs
 %! A = sym([1 2; 2 4]);
 %! b = [vpa('1.01'); vpa('2')];

--- a/inst/@sym/sym.m
+++ b/inst/@sym/sym.m
@@ -1,5 +1,5 @@
 %% SPDX-License-Identifier: GPL-3.0-or-later
-%% Copyright (C) 2014-2019, 2022-2024 Colin B. Macdonald
+%% Copyright (C) 2014-2019, 2022-2025 Colin B. Macdonald
 %% Copyright (C) 2016 Lagu
 %%
 %% This file is part of OctSymPy.
@@ -630,6 +630,7 @@ end
 %! assert (isequal (2*x, sym (1)))
 
 %!warning <dangerous> x = sym (1/2);
+%!warning id=OctSymPy:sym:rationalapprox x = sym (1/2);
 
 %!test
 %! % passing small rationals w/o quotes: despite the warning,
@@ -935,12 +936,12 @@ end
 
 %!assert (~ isequal (sym (exp(1)), sym (exp(1), 'f')))
 
-%!warning <dangerous> sym (1e16);
-%!warning <dangerous> sym (-1e16);
-%!warning <dangerous> sym (10.33);
-%!warning <dangerous> sym (-5.23);
-%!warning <dangerous> sym (sqrt (1.4142135623731));
-%!warning <dangerous> sym ([1.2 1.3]);
+%!warning id=OctSymPy:sym:rationalapprox sym (1e16);
+%!warning id=OctSymPy:sym:rationalapprox sym (-1e16);
+%!warning id=OctSymPy:sym:rationalapprox sym (10.33);
+%!warning id=OctSymPy:sym:rationalapprox sym (-5.23);
+%!warning id=OctSymPy:sym:rationalapprox sym (sqrt (1.4142135623731));
+%!warning id=OctSymPy:sym:rationalapprox sym ([1.2 1.3]);
 
 %!error <is not supported>
 %! x = sym ('x', 'positive2');

--- a/inst/@sym/toeplitz.m
+++ b/inst/@sym/toeplitz.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2019, 2025 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -121,12 +121,12 @@ end
 %! B = toeplitz([a,b,c]);
 %! assert (isequal( A, B))
 
-%!warning <diagonal conflict>
+%!warning id=OctSymPy:toeplitz:diagconflict
 %! % mismatch
 %! syms x
 %! B = toeplitz([10 x], [1 3 x]);
 
-%!warning <diagonal conflict>
+%!warning id=OctSymPy:toeplitz:diagconflict
 %! % scalar
 %! B = toeplitz(sym(2), 3);
 %! assert (isequal (B, sym(2)))

--- a/inst/vpa.m
+++ b/inst/vpa.m
@@ -390,7 +390,9 @@ end
 
 %!warning <dangerous> vpa ('sqrt(2.0)');
 
-%!warning <dangerous>
+%!warning id=OctSymPy:vpa:precisionloss vpa ('sqrt(2.0)');
+
+%!warning id=OctSymPy:vpa:precisionloss
 %! a = vpa('2**0.5');
 %! b = vpa(sqrt(sym(2)));
 %! assert (isequal (a, b))

--- a/inst/vpa.m
+++ b/inst/vpa.m
@@ -1,5 +1,5 @@
 %% SPDX-License-Identifier: GPL-3.0-or-later
-%% Copyright (C) 2014-2019, 2021-2022, 2024 Colin B. Macdonald
+%% Copyright (C) 2014-2019, 2021-2022, 2024-2025 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -355,36 +355,36 @@ end
 
 %!test
 %! % isequal and other comparisons
-%! a = vpa ("2/3", 32);
-%! b = vpa ("2/3", 64);
+%! a = vpa ('2/3', 32);
+%! b = vpa ('2/3', 64);
 %! assert (~ logical (a == b))
 %! assert (~ isequal (a, b))
-%! a = vpa ("1/3", 32);
-%! b = vpa ("1/3", 64);
+%! a = vpa ('1/3', 32);
+%! b = vpa ('1/3', 64);
 %! assert (~ logical (a == b))
 %! assert (~ isequal (a, b))
-%! a = vpa ("0.1", 32);
-%! b = vpa ("0.1", 64);
+%! a = vpa ('0.1', 32);
+%! b = vpa ('0.1', 64);
 %! assert (~ logical (a == b))
 %! assert (~ isequal (a, b))
 
 %!test
 %! % isequal with array: Issue #1285
-%! a = vpa ("2/3", 32);
-%! b = vpa ("2/3", 64);
+%! a = vpa ('2/3', 32);
+%! b = vpa ('2/3', 64);
 %! assert (~ isequal ([a 2*a], [b 2*b]))
 
 %!xtest
 %! % non-equality of vpa that "might be" be integers: Issue #1285
-%! a = vpa ("123", 32);
-%! b = vpa ("123", 64);
+%! a = vpa ('123', 32);
+%! b = vpa ('123', 64);
 %! assert (~ logical (a == b))
 
 %!test
 %! % non-equality of vpa that "might be" be integers: Issue #1285
 %! if (pycall_sympy__ ('return Version(spver) >= Version("1.13.0")'))
-%!   a = vpa ("123", 32);
-%!   b = vpa ("123", 64);
+%!   a = vpa ('123', 32);
+%!   b = vpa ('123', 64);
 %!   assert (~ isequal (a, b))
 %! end
 


### PR DESCRIPTION
Looked like we had some work to do for Octave 10 in #1321.  All seem resolved on current `default` branch (what will become Octave 11).  But here's some cleanups I did while looking into #1321.